### PR TITLE
reduce unnecessary recompilation of buffers_cu, add refresh_settings method

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,7 @@
+.vscode/
+__pycache__/
+*.pyc
+*.egg-info
+.idea/
+.pytest_cache/
+.cache/

--- a/warpdrive/buffers.py
+++ b/warpdrive/buffers.py
@@ -78,6 +78,22 @@ class Buffer(to_subclass):
 
         #---- get compiled function handles
         self._get_compiled_modules()
+    
+    def refresh_settings(self, percentile, buffer_length):
+        self.buffer_length = buffer_length
+        self.percentile = percentile
+
+        self.index_to_grab = np.int32(max([round(self.percentile * buffer_length) - 1, 0]))
+
+        self.cur_frames = set()
+        self.cur_positions = {}
+        self.available = list(range(buffer_length))
+        
+        # reallocate frames arrays
+        pix_r, pix_c = self.slice_shape
+        # TODO - ideally can initialize as empty, but inf is a part of hacky fix to pass test_recycling_after_IOError
+        self.frames = np.inf*np.ones((pix_r, pix_c, self.buffer_length), np.float32)  # self.frames = np.empty((pix_r, pix_c, self.buffer_length), np.float32)
+        self.frames_gpu = cuda.mem_alloc(self.frames.size * self.frames.dtype.itemsize)
 
     def _get_compiled_modules(self):
         """


### PR DESCRIPTION
addresses issue #4 by:
- moving buffers pycuda module compilation into `buffers.py` import rather than `buffer.Buffer.__init__`

addresses todo statement in `PYME.localization.remFitBuf` by:
- adding a `refresh_settings` method to `Buffer` to check/update percentile and buffer length. Logic is already in place to make sure the datasource is the same.