### PR TITLE
fix find_peaks indexing, simplify dog_colum indexing

### DIFF
--- a/warpdrive/detector.py
+++ b/warpdrive/detector.py
@@ -346,10 +346,10 @@ class detector(object):
 
         # fixme - make sure units on findpeaks.cu are all set once filter.cu is consistent
         # take maximum filter
-        self.maxfrow(self.unif1_gpu, self.maxf_data_gpu, self.n_columns, self.halfMaxFilt, block=(self.ncolumns, 1, 1),
+        self.maxfrow(self.unif1_gpu, self.maxf_data_gpu, self.halfMaxFilt, block=(self.ncolumns, 1, 1),
                      grid=(self.nrows, 1), stream=self.main_stream_r)
 
-        self.maxfcol(self.maxf_data_gpu, self.n_columns, self.halfMaxFilt, block=(self.nrows, 1, 1),
+        self.maxfcol(self.maxf_data_gpu, self.halfMaxFilt, block=(self.nrows, 1, 1),
                      grid=(self.ncolumns, 1), stream=self.main_stream_r)
 
         self.find_candidates_noise_thresh(self.unif1_gpu, self.maxf_data_gpu, np.float32(thresh), self.n_candidates_gpu,

--- a/warpdrive/filter.cu
+++ b/warpdrive/filter.cu
@@ -191,7 +191,7 @@ be convolved by this function is 1024x1024, because each pixel is assigned its o
 
     // pad shared mem column
     if (j < (halfFilt)){
-        cdata_sh[j][0] = 0;
+        cdata_sh[j] = 0;
         cdata_sh[rowsize + j + halfFilt] = 0;
         //printf("colsize + halfFilt %d", (colsize + halfFilt));
     }

--- a/warpdrive/filter.cu
+++ b/warpdrive/filter.cu
@@ -186,17 +186,17 @@ be convolved by this function is 1024x1024, because each pixel is assigned its o
     float tempsum = 0;
 
     // allocated column of shared memory
-    volatile __shared__ float cdata_sh[1075][1]; //should be changed to rowsize
+    volatile __shared__ float cdata_sh[1075]; //should be changed to rowsize
     __shared__ float filter_sh[12];
 
     // pad shared mem column
     if (j < (halfFilt)){
         cdata_sh[j][0] = 0;
-        cdata_sh[rowsize + j + halfFilt][0] = 0;
+        cdata_sh[rowsize + j + halfFilt] = 0;
         //printf("colsize + halfFilt %d", (colsize + halfFilt));
     }
     // load data column into shared mem
-    cdata_sh[j + halfFilt][0] = data[j*colsize + cid];
+    cdata_sh[j + halfFilt] = data[j*colsize + cid];
     // load filter into shared mem
     if (j < (2*halfFilt)) filter_sh[j] = filter[j];
 
@@ -205,7 +205,7 @@ be convolved by this function is 1024x1024, because each pixel is assigned its o
 
     // perform convolution
     for (k = -halfFilt; k <= halfFiltm1; k++){
-        tempsum += cdata_sh[(j + halfFilt) - k][0]*filter_sh[k + halfFilt];
+        tempsum += cdata_sh[(j + halfFilt) - k]*filter_sh[k + halfFilt];
     }
 
     // store results in input array

--- a/warpdrive/find_peaks.cu
+++ b/warpdrive/find_peaks.cu
@@ -82,7 +82,7 @@ Currently, the maximum size array that can be convolved by this function is
     __syncthreads();
 
     for (k = -half_filter_size; k <= half_filter_size - 1; k++){
-        tem_pmax = fmaxf(cdata_sh[(threadIdx.x + half_filter_size) - k], temp_max);
+        temp_max = fmaxf(cdata_sh[(threadIdx.x + half_filter_size) - k], temp_max);
     }
     rconvdata[ind] = temp_max;
 


### PR DESCRIPTION
there was a +1 that wasn't needed in loading into shared memory, which would leave the first non-pad pixel undefined. Was also going one farther than necessary in the max search.

Simplify shared memory shape in dog_column